### PR TITLE
Localize band descriptions (German default + English)

### DIFF
--- a/docs/localized-band-description.md
+++ b/docs/localized-band-description.md
@@ -1,0 +1,121 @@
+# Localized band descriptions
+
+Band descriptions are served in **two languages**: German (`de`, the default)
+and English (`en`). German is the primary language — English is optional and may
+be `null` for a given band.
+
+## API shape
+
+`description` is no longer a plain string. On every endpoint that returns a band
+(`GET /api/festivals/{festivalSlug}/bands` and
+`GET /api/festivals/{festivalSlug}/{bandSlug}`) it is a localized object:
+
+```json
+{
+  "id": 8,
+  "name": "Amorphis",
+  "slug": "amorphis",
+  "genre": "Melodic Death / Heavy Metal",
+  "description": {
+    "de": "Metal-Band aus Helsinki, Finnland, gegründet 1990 …",
+    "en": "Metal band from Helsinki, Finland, formed in 1990 …"
+  }
+}
+```
+
+Either field may be `null`:
+
+```json
+"description": { "de": "Deutsche Beschreibung …", "en": null }
+```
+
+Both keys are always present in the response (the value is `null` when there is
+no copy for that language). German is the default — show it unless the user
+prefers English, and fall back to it when the preferred language is `null`.
+
+> **Breaking change.** Previously `description` was a `string`. Clients that read
+> it as a string must be updated to read `description.de` / `description.en`.
+
+## iOS implementation (Swift)
+
+A tiny reusable `Codable` type plus one computed property covers everything.
+
+```swift
+import Foundation
+
+/// A piece of text the API provides in German (default) and English.
+struct LocalizedText: Codable, Hashable {
+    let de: String?
+    let en: String?
+
+    /// Text for the user's current language, German-first with a fallback to
+    /// whichever language is actually present.
+    var localized: String? {
+        let prefersEnglish = Locale.current.language.languageCode?.identifier == "en"
+        if prefersEnglish {
+            return en ?? de          // English preferred, fall back to German
+        }
+        return de ?? en              // German default, fall back to English
+    }
+}
+
+struct Band: Codable, Identifiable {
+    let id: Int
+    let name: String
+    let slug: String
+    let genre: String?
+    let logo: String
+    let image: String
+    let instagram: String?
+    let spotify: String?
+    let appleMusic: String?
+    let bandcamp: String?
+    let description: LocalizedText
+}
+```
+
+Usage in a view:
+
+```swift
+if let text = band.description.localized {
+    Text(text)
+}
+```
+
+### Letting the user override the language
+
+If your app has an in-app language switch instead of relying on the device
+locale, pass the preference in rather than reading `Locale.current`:
+
+```swift
+extension LocalizedText {
+    func text(for language: AppLanguage) -> String? {
+        switch language {
+        case .german:  return de ?? en
+        case .english: return en ?? de
+        }
+    }
+}
+```
+
+That's the whole integration: decode `description` as `LocalizedText` and call
+`localized` (or `text(for:)`) wherever you currently show the description.
+
+## Data model & backend notes
+
+- The `Band` entity stores two nullable `TEXT` columns: `description_de` (the
+  default) and `description_en`.
+- Migration `Version20260623120000` renames the legacy `description` column to
+  `description_en` (it held English copy) and adds an empty `description_de`.
+  Run it and then re-seed:
+
+  ```bash
+  php bin/console doctrine:migrations:migrate
+  php bin/console app:seed:band-details --overwrite
+  ```
+
+- The EasyAdmin band form exposes both as **Description (DE)** and
+  **Description (EN)** editors.
+- To add a third language later, add a `description_xx` column + getter/setter,
+  emit the key in `FestivalApiController`, and add the field to `LocalizedText`
+  in `openapi.yaml`. No client breakage — new keys are additive.

--- a/migrations/Version20260623120000.php
+++ b/migrations/Version20260623120000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Split the single band `description` into per-language columns.
+ *
+ * German (`description_de`) is the default language; English (`description_en`)
+ * is optional. The legacy `description` column held English copy, so it is
+ * renamed to `description_en` to preserve existing data; `description_de` is
+ * added empty and populated by `app:seed:band-details`.
+ */
+final class Version20260623120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Split band.description into description_de (default) and description_en';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band CHANGE description description_en LONGTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE band ADD description_de LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE band DROP description_de');
+        $this->addSql('ALTER TABLE band CHANGE description_en description VARCHAR(255) DEFAULT NULL');
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,6 +10,7 @@ info:
     - `logo` / `image` are returned as absolute URLs built as `{host}/images/band/{logos|images}/{filename}`. When the underlying value is null the URL ends with a trailing slash.
     - `GET /api/festivals`, `.../stages` and `.../stages/{stageSlug}` return compact arrays. `startDate` / `endDate` are `YYYY-MM-DD` strings.
     - On the time-slot and band-detail endpoints, `startTime` / `endTime` are still serialized by Symfony's ObjectNormalizer as a **verbose PHP `DateTime` object** (`$ref: PhpDateTime`). `GET .../upnext` returns a preformatted string.
+    - `description` is a **localized object** (`$ref: LocalizedText`) with a `de` (German, the default language) and an `en` (English) field. Either field may be `null`. Clients should display `de` by default and fall back to it when the user's locale is English but `en` is `null` (or vice versa).
 servers:
   - url: https://bands.baphomet.club
     description: Production
@@ -188,7 +189,9 @@ components:
         spotify: { type: string, nullable: true }
         appleMusic: { type: string, nullable: true }
         bandcamp: { type: string, nullable: true }
-        description: { type: string, nullable: true }
+        description:
+          allOf: [{ $ref: "#/components/schemas/LocalizedText" }]
+          description: Localized band description (German default + English).
 
     Stage:
       type: object
@@ -218,8 +221,8 @@ components:
             appleMusic: { type: string, nullable: true }
             bandcamp: { type: string, nullable: true }
             description:
-              type: string
-              nullable: true
+              allOf: [{ $ref: "#/components/schemas/LocalizedText" }]
+              description: Localized band description (German default + English).
         startTime:
           allOf: [{ $ref: "#/components/schemas/PhpDateTime" }]
           description: Present only when the band has a time slot at this festival.
@@ -255,6 +258,26 @@ components:
           example: "21:00:00 16.07.2026 "
         band: { type: string, example: "Amorphis" }
         stage: { type: string, example: "Hauptbühne" }
+
+    LocalizedText:
+      type: object
+      description: |
+        A piece of text in the API's supported languages. `de` (German) is the
+        default and should be shown unless the client explicitly prefers English.
+        Either field may be null when no copy exists for that language; clients
+        fall back to the other language in that case.
+      properties:
+        de:
+          type: string
+          nullable: true
+          description: German text (default language).
+          example: "Melodic-Death- und Folk-Metal-Band aus Duisburg …"
+        en:
+          type: string
+          nullable: true
+          description: English text. Null when no English copy is available.
+          example: "Melodic death and folk metal band from Duisburg, Germany …"
+      required: [de, en]
 
     PhpDateTime:
       type: object

--- a/src/Command/SeedBandDetailsCommand.php
+++ b/src/Command/SeedBandDetailsCommand.php
@@ -22,7 +22,10 @@ class SeedBandDetailsCommand extends Command
      * profiles; a null field means no official profile was confirmed (left
      * untouched so manual data is never overwritten with null).
      *
-     * @var array<string, array{genre:string, instagram:?string, spotify:?string, appleMusic:?string, bandcamp:?string, description:string}>
+     * `descriptionDe` is the default language; `descriptionEn` is the optional
+     * English translation.
+     *
+     * @var array<string, array{genre:string, instagram:?string, spotify:?string, appleMusic:?string, bandcamp:?string, descriptionDe:string, descriptionEn:string}>
      */
     private const DETAILS = [
         'aereum' => [
@@ -31,7 +34,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/4InllsE71WEGbU1sM1nUtN',
             'appleMusic' => 'https://music.apple.com/us/artist/aereum/1492839659',
             'bandcamp' => 'https://aereum.bandcamp.com/',
-            'description' => 'Melodic death and folk metal band from Duisburg, Germany, whose lyrics weave the mysticism of ancient Egypt with earthy themes. Debut album "Tempest of Time" (2020).',
+            'descriptionDe' => 'Melodic-Death- und Folk-Metal-Band aus Duisburg, deren Texte die Mystik des alten Ägypten mit erdverbundenen Themen verweben. Debütalbum „Tempest of Time" (2020).',
+            'descriptionEn' => 'Melodic death and folk metal band from Duisburg, Germany, whose lyrics weave the mysticism of ancient Egypt with earthy themes. Debut album "Tempest of Time" (2020).',
         ],
         'onyxsin' => [
             'genre' => 'Alternative Metal / Metalcore',
@@ -39,7 +43,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/6JKpO4OLTJAkwdwa8yt2UF',
             'appleMusic' => 'https://music.apple.com/de/artist/onyxsin/1711274642',
             'bandcamp' => null,
-            'description' => 'Metal trio from Duisburg, Germany, formed in late 2021, blending metalcore and hard rock with prog and melodic death metal under the motto "both hard and melodic".',
+            'descriptionDe' => 'Metal-Trio aus Duisburg, gegründet Ende 2021, das Metalcore und Hard Rock mit Prog und Melodic Death Metal verbindet – nach dem Motto „hart und melodisch zugleich".',
+            'descriptionEn' => 'Metal trio from Duisburg, Germany, formed in late 2021, blending metalcore and hard rock with prog and melodic death metal under the motto "both hard and melodic".',
         ],
         'opus-maxima' => [
             'genre' => 'Djent / Progressive Deathcore',
@@ -47,7 +52,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/20XGECH8f1iYiduEfH9w7r',
             'appleMusic' => 'https://music.apple.com/us/artist/opus-maxima/1336067467',
             'bandcamp' => 'https://opusmaximaofficial.bandcamp.com/',
-            'description' => 'Djent and progressive deathcore band from Mexico City, Mexico, known for 8-string riffs and heavy breakdowns. Album "El Renacer" (2021).',
+            'descriptionDe' => 'Djent- und Progressive-Deathcore-Band aus Mexiko-Stadt, bekannt für 8-saitige Riffs und wuchtige Breakdowns. Album „El Renacer" (2021).',
+            'descriptionEn' => 'Djent and progressive deathcore band from Mexico City, Mexico, known for 8-string riffs and heavy breakdowns. Album "El Renacer" (2021).',
         ],
         'homecoming' => [
             'genre' => 'Post-Metal / Progressive Metal',
@@ -55,7 +61,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/5qad2jhw9rXk2MlKO1khL1',
             'appleMusic' => null,
             'bandcamp' => 'https://wearehomecoming.bandcamp.com/',
-            'description' => 'Post-metal and progressive metal quartet from Paris, France, fusing sludge, grunge, 90s alternative rock and prog. Albums "LP01" (2019) and "Those We Knew" (2024).',
+            'descriptionDe' => 'Post-Metal- und Progressive-Metal-Quartett aus Paris, das Sludge, Grunge, 90er-Alternative-Rock und Prog verbindet. Alben „LP01" (2019) und „Those We Knew" (2024).',
+            'descriptionEn' => 'Post-metal and progressive metal quartet from Paris, France, fusing sludge, grunge, 90s alternative rock and prog. Albums "LP01" (2019) and "Those We Knew" (2024).',
         ],
         'octoploid' => [
             'genre' => 'Melodic Death / Progressive Metal',
@@ -63,7 +70,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/712moi8jSAse1lYXB6rU4R',
             'appleMusic' => 'https://music.apple.com/ca/artist/octoploid/1736843645',
             'bandcamp' => null,
-            'description' => 'Solo project of Amorphis founding bassist Olli-Pekka Laine (Finland), blending 90s death/black metal with 70s prog. Debut album "Beyond the Aeons" (2024).',
+            'descriptionDe' => 'Soloprojekt von Amorphis-Gründungsbassist Olli-Pekka Laine (Finnland), das 90er-Death-/Black-Metal mit 70er-Prog verbindet. Debütalbum „Beyond the Aeons" (2024).',
+            'descriptionEn' => 'Solo project of Amorphis founding bassist Olli-Pekka Laine (Finland), blending 90s death/black metal with 70s prog. Debut album "Beyond the Aeons" (2024).',
         ],
         'non-est-deus' => [
             'genre' => 'Melodic Black Metal',
@@ -71,7 +79,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/3CAMaX2bss4c0E7K4O0dTf',
             'appleMusic' => 'https://music.apple.com/us/artist/non-est-deus/1598304436',
             'bandcamp' => 'https://noisebringer-records.bandcamp.com/',
-            'description' => 'Melodic black metal project from Bamberg, Germany, formed in 2017 by the anonymous musician "Noise" (also of Kanonenfieber), themed around the rejection of religious fanaticism.',
+            'descriptionDe' => 'Melodic-Black-Metal-Projekt aus Bamberg, 2017 vom anonymen Musiker „Noise" (auch bei Kanonenfieber) gegründet, dessen Thema die Ablehnung religiösen Fanatismus ist.',
+            'descriptionEn' => 'Melodic black metal project from Bamberg, Germany, formed in 2017 by the anonymous musician "Noise" (also of Kanonenfieber), themed around the rejection of religious fanaticism.',
         ],
         'subway-to-sally' => [
             'genre' => 'Medieval Folk Metal',
@@ -79,7 +88,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/544X9aDcwFDSon8HevRcqg',
             'appleMusic' => 'https://music.apple.com/us/artist/subway-to-sally/13498062',
             'bandcamp' => 'https://subwaytosally.bandcamp.com/',
-            'description' => 'German medieval/folk metal band formed in Potsdam in 1990, blending metal with bagpipes, hurdy-gurdy, shawm and violin, mostly singing in German.',
+            'descriptionDe' => 'Deutsche Mittelalter-/Folk-Metal-Band, 1990 in Potsdam gegründet, die Metal mit Dudelsack, Drehleier, Schalmei und Violine verbindet und überwiegend auf Deutsch singt.',
+            'descriptionEn' => 'German medieval/folk metal band formed in Potsdam in 1990, blending metal with bagpipes, hurdy-gurdy, shawm and violin, mostly singing in German.',
         ],
         'amorphis' => [
             'genre' => 'Melodic Death / Heavy Metal',
@@ -87,7 +97,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/2UOVgpgiNTC6KK0vSC77aD',
             'appleMusic' => 'https://music.apple.com/fi/artist/amorphis/5545051',
             'bandcamp' => null,
-            'description' => 'Metal band from Helsinki, Finland, formed in 1990, blending melodic death and heavy metal with progressive and folk elements and lyrics drawn from the Kalevala.',
+            'descriptionDe' => 'Metal-Band aus Helsinki, Finnland, gegründet 1990, die Melodic Death und Heavy Metal mit progressiven und Folk-Elementen verbindet; die Texte schöpfen aus dem Kalevala.',
+            'descriptionEn' => 'Metal band from Helsinki, Finland, formed in 1990, blending melodic death and heavy metal with progressive and folk elements and lyrics drawn from the Kalevala.',
         ],
         'hold-your-ground' => [
             'genre' => 'Hardcore Punk',
@@ -95,7 +106,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/5yhHa68oOzZLNIS9i8NAaT',
             'appleMusic' => null,
             'bandcamp' => 'https://holdyourground1.bandcamp.com/',
-            'description' => 'Four-piece hardcore-punk band from Lünen, Germany, formed in 2021, playing short, direct, energetic songs.',
+            'descriptionDe' => 'Vierköpfige Hardcore-Punk-Band aus Lünen, gegründet 2021, die kurze, direkte und energiegeladene Songs spielt.',
+            'descriptionEn' => 'Four-piece hardcore-punk band from Lünen, Germany, formed in 2021, playing short, direct, energetic songs.',
         ],
         'vorga' => [
             'genre' => 'Atmospheric Black Metal',
@@ -103,7 +115,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/4VeQnaE38lgZIDrYPUYOA8',
             'appleMusic' => 'https://music.apple.com/us/artist/vorga/1454170253',
             'bandcamp' => 'https://vorga.bandcamp.com/',
-            'description' => 'Sci-fi-themed melodic/atmospheric black metal band founded in 2016, based in Karlsruhe, Germany. Album "Beyond the Palest Star" (2024) via Transcending Obscurity.',
+            'descriptionDe' => 'Sci-Fi-thematisierte Melodic-/Atmospheric-Black-Metal-Band, 2016 gegründet, ansässig in Karlsruhe. Album „Beyond the Palest Star" (2024) bei Transcending Obscurity.',
+            'descriptionEn' => 'Sci-fi-themed melodic/atmospheric black metal band founded in 2016, based in Karlsruhe, Germany. Album "Beyond the Palest Star" (2024) via Transcending Obscurity.',
         ],
         'vansind' => [
             'genre' => 'Folk Metal',
@@ -111,7 +124,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/0Nykhf9j9EMdq4K8LeaDfe',
             'appleMusic' => 'https://music.apple.com/us/artist/vansind/1501668341',
             'bandcamp' => 'https://vansind.bandcamp.com/',
-            'description' => 'Folk metal band formed in 2019 in Slagelse, Denmark, blending Viking/folk metal with lyrics drawn from Norse mythology and Scandinavian history.',
+            'descriptionDe' => 'Folk-Metal-Band, 2019 im dänischen Slagelse gegründet, die Viking-/Folk-Metal mit Texten aus der nordischen Mythologie und skandinavischen Geschichte verbindet.',
+            'descriptionEn' => 'Folk metal band formed in 2019 in Slagelse, Denmark, blending Viking/folk metal with lyrics drawn from Norse mythology and Scandinavian history.',
         ],
         'submasq' => [
             'genre' => 'Progressive Oriental Metal',
@@ -119,7 +133,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/06JYsafBUf9AGI0SUd4tY2',
             'appleMusic' => 'https://music.apple.com/us/artist/subterranean-masquerade/79486100',
             'bandcamp' => 'https://submasq.bandcamp.com/',
-            'description' => 'Subterranean Masquerade (SubMasq) is a progressive oriental/psychedelic metal band from Israel, founded in 1997, blending avant-garde metal with Middle Eastern influences.',
+            'descriptionDe' => 'Subterranean Masquerade (SubMasq) ist eine Progressive-Oriental-/Psychedelic-Metal-Band aus Israel, gegründet 1997, die Avantgarde-Metal mit nahöstlichen Einflüssen verbindet.',
+            'descriptionEn' => 'Subterranean Masquerade (SubMasq) is a progressive oriental/psychedelic metal band from Israel, founded in 1997, blending avant-garde metal with Middle Eastern influences.',
         ],
         'night-in-gales' => [
             'genre' => 'Melodic Death Metal',
@@ -127,7 +142,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/16l3GG2iL03FXfxJaNx1rC',
             'appleMusic' => null,
             'bandcamp' => 'https://nightingalesmerch.bandcamp.com/',
-            'description' => 'German melodic death metal band from North Rhine-Westphalia, active since 1995. Ninth album "Shadowreaper" (2024).',
+            'descriptionDe' => 'Deutsche Melodic-Death-Metal-Band aus Nordrhein-Westfalen, aktiv seit 1995. Neuntes Album „Shadowreaper" (2024).',
+            'descriptionEn' => 'German melodic death metal band from North Rhine-Westphalia, active since 1995. Ninth album "Shadowreaper" (2024).',
         ],
         'goldsmith' => [
             'genre' => 'Heavy Rock',
@@ -135,7 +151,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/3cMgrUPLwJg5aky4Z4sszv',
             'appleMusic' => null,
             'bandcamp' => null,
-            'description' => 'Heavy rock band from Freiburg, Germany, founded by guitarist/vocalist Michael Goldschmidt, blending traditional heavy metal, thrash, hard rock and punk.',
+            'descriptionDe' => 'Heavy-Rock-Band aus Freiburg, gegründet von Gitarrist und Sänger Michael Goldschmidt, die traditionellen Heavy Metal, Thrash, Hard Rock und Punk verbindet.',
+            'descriptionEn' => 'Heavy rock band from Freiburg, Germany, founded by guitarist/vocalist Michael Goldschmidt, blending traditional heavy metal, thrash, hard rock and punk.',
         ],
         'grailknights' => [
             'genre' => 'Power Metal',
@@ -143,7 +160,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/3WKWdx78zcqsj2RkN5ldqR',
             'appleMusic' => null,
             'bandcamp' => null,
-            'description' => 'German power metal band from Wunstorf known for theatrical superhero personas and fantasy-themed lyrics. Album "Forever" (2025).',
+            'descriptionDe' => 'Deutsche Power-Metal-Band aus Wunstorf, bekannt für theatralische Superhelden-Personas und Fantasy-Texte. Album „Forever" (2025).',
+            'descriptionEn' => 'German power metal band from Wunstorf known for theatrical superhero personas and fantasy-themed lyrics. Album "Forever" (2025).',
         ],
         'creeper' => [
             'genre' => 'Horror Punk / Gothic Rock',
@@ -151,7 +169,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/0nV7SiEIVtPLTSJ6NwWDGj',
             'appleMusic' => null,
             'bandcamp' => null,
-            'description' => 'British band from Southampton, England, formed in 2014, whose concept albums span horror punk, glam rock and gothic rock; fronted by Will Gould.',
+            'descriptionDe' => 'Britische Band aus Southampton, gegründet 2014, deren Konzeptalben Horror-Punk, Glam-Rock und Gothic-Rock umspannen; Frontmann ist Will Gould.',
+            'descriptionEn' => 'British band from Southampton, England, formed in 2014, whose concept albums span horror punk, glam rock and gothic rock; fronted by Will Gould.',
         ],
         'satyricon' => [
             'genre' => 'Black Metal',
@@ -159,7 +178,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/221Rd0FvVxMx7eCbWqjiKd',
             'appleMusic' => null,
             'bandcamp' => 'https://satyricon.bandcamp.com/',
-            'description' => 'Norwegian black metal band formed in Oslo in 1991, led by Satyr and Frost; one of the most prominent acts in Norwegian black metal.',
+            'descriptionDe' => 'Norwegische Black-Metal-Band, 1991 in Oslo gegründet, angeführt von Satyr und Frost; eine der prägendsten Bands des norwegischen Black Metal.',
+            'descriptionEn' => 'Norwegian black metal band formed in Oslo in 1991, led by Satyr and Frost; one of the most prominent acts in Norwegian black metal.',
         ],
         'skindred' => [
             'genre' => 'Ragga Metal',
@@ -167,7 +187,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/3jTlKw98Ql1jGRPYqhqHap',
             'appleMusic' => null,
             'bandcamp' => null,
-            'description' => 'Welsh band from Newport formed in 1998 fusing heavy metal with reggae, a style they call ragga metal. 2026 album "You Got This" topped the UK Albums Chart.',
+            'descriptionDe' => 'Walisische Band aus Newport, gegründet 1998, die Heavy Metal mit Reggae verschmilzt – ein Stil, den sie Ragga Metal nennen. Das Album „You Got This" (2026) führte die UK-Albumcharts an.',
+            'descriptionEn' => 'Welsh band from Newport formed in 1998 fusing heavy metal with reggae, a style they call ragga metal. 2026 album "You Got This" topped the UK Albums Chart.',
         ],
         'goatfather' => [
             'genre' => 'Stoner Rock',
@@ -175,7 +196,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/6ZSawiJyYTvdaCzQ25QwyM',
             'appleMusic' => 'https://music.apple.com/us/artist/goatfather/1160685342',
             'bandcamp' => 'https://goatfather.bandcamp.com/',
-            'description' => 'Stoner/Southern rock quartet formed in 2014 in Lyon, France. Third album "House of the Rising Smoke" (2025) via Argonauta Records.',
+            'descriptionDe' => 'Stoner-/Southern-Rock-Quartett, 2014 im französischen Lyon gegründet. Drittes Album „House of the Rising Smoke" (2025) bei Argonauta Records.',
+            'descriptionEn' => 'Stoner/Southern rock quartet formed in 2014 in Lyon, France. Third album "House of the Rising Smoke" (2025) via Argonauta Records.',
         ],
         'snakebite' => [
             'genre' => 'Hard Rock / Heavy Metal',
@@ -183,7 +205,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/50WEDFpbZjnsOda59ai38R',
             'appleMusic' => 'https://music.apple.com/us/artist/snakebite/3992097',
             'bandcamp' => 'https://snakebite-music.bandcamp.com/',
-            'description' => 'Hard rock/heavy metal band from Essen, Germany, drawing on 80s rock and metal influences. Album "Cobra Crew" (2024).',
+            'descriptionDe' => 'Hard-Rock-/Heavy-Metal-Band aus Essen, die auf Rock- und Metal-Einflüssen der 80er aufbaut. Album „Cobra Crew" (2024).',
+            'descriptionEn' => 'Hard rock/heavy metal band from Essen, Germany, drawing on 80s rock and metal influences. Album "Cobra Crew" (2024).',
         ],
         'gangrena-gasosa' => [
             'genre' => 'Saravá Metal / Crossover Thrash',
@@ -191,7 +214,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/7bmlMF1tQCEqpaW0apBGEh',
             'appleMusic' => 'https://music.apple.com/us/artist/gangrena-gasosa/1018527747',
             'bandcamp' => null,
-            'description' => 'Brazilian band from Rio de Janeiro that pioneered "saravá metal", a humorous fusion of crossover thrash, hardcore and Afro-Brazilian (Umbanda) elements. Album "Figa Of The Dark" (2024).',
+            'descriptionDe' => 'Brasilianische Band aus Rio de Janeiro, die den „Saravá Metal" begründete – eine humorvolle Fusion aus Crossover-Thrash, Hardcore und afrobrasilianischen (Umbanda-)Elementen. Album „Figa Of The Dark" (2024).',
+            'descriptionEn' => 'Brazilian band from Rio de Janeiro that pioneered "saravá metal", a humorous fusion of crossover thrash, hardcore and Afro-Brazilian (Umbanda) elements. Album "Figa Of The Dark" (2024).',
         ],
         'synsnake' => [
             'genre' => 'Metalcore',
@@ -199,7 +223,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/77gfMqeW2CqUi95Fwi1onA',
             'appleMusic' => 'https://music.apple.com/us/artist/synsnake/1121539493',
             'bandcamp' => 'https://synsnake.bandcamp.com/',
-            'description' => 'South Korean metalcore band from Seoul, formed in 2015, known for coining "K-popcore". Second album "Nodes" (2025).',
+            'descriptionDe' => 'Südkoreanische Metalcore-Band aus Seoul, gegründet 2015, bekannt für die Prägung des Begriffs „K-popcore". Zweites Album „Nodes" (2025).',
+            'descriptionEn' => 'South Korean metalcore band from Seoul, formed in 2015, known for coining "K-popcore". Second album "Nodes" (2025).',
         ],
         'impureza' => [
             'genre' => 'Death Metal (Hispanic Metal)',
@@ -207,7 +232,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/3YA9Uqs38ZD6Lg2q66PVw9',
             'appleMusic' => 'https://music.apple.com/us/artist/impureza/422671948',
             'bandcamp' => 'https://impureza.bandcamp.com/',
-            'description' => 'Franco-Spanish band formed in 2004 fusing brutal death metal with flamenco guitar and Spanish vocals — "Hispanic Metal". Album "Alcázares" (2025) via Season of Mist.',
+            'descriptionDe' => 'Französisch-spanische Band, gegründet 2004, die Brutal Death Metal mit Flamenco-Gitarre und spanischem Gesang verbindet – „Hispanic Metal". Album „Alcázares" (2025) bei Season of Mist.',
+            'descriptionEn' => 'Franco-Spanish band formed in 2004 fusing brutal death metal with flamenco guitar and Spanish vocals — "Hispanic Metal". Album "Alcázares" (2025) via Season of Mist.',
         ],
         'detartrated' => [
             'genre' => 'Deathcore',
@@ -215,7 +241,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/03V1hykDrJWlq0kzEQkNBe',
             'appleMusic' => 'https://music.apple.com/de/artist/detartrated/1804598727',
             'bandcamp' => 'https://detartrated.bandcamp.com/',
-            'description' => 'German orchestral deathcore band from the Castrop-Rauxel area, formed in 2024, combining crushing breakdowns with orchestral atmospheres.',
+            'descriptionDe' => 'Deutsche Orchestral-Deathcore-Band aus dem Raum Castrop-Rauxel, gegründet 2024, die wuchtige Breakdowns mit orchestralen Atmosphären verbindet.',
+            'descriptionEn' => 'German orchestral deathcore band from the Castrop-Rauxel area, formed in 2024, combining crushing breakdowns with orchestral atmospheres.',
         ],
         'bonded' => [
             'genre' => 'Thrash Metal',
@@ -223,7 +250,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/7IqK0RqRcaTDtVJtblZ0HQ',
             'appleMusic' => 'https://music.apple.com/us/artist/bonded/1487156987',
             'bandcamp' => 'https://bonded.bandcamp.com/',
-            'description' => 'German thrash/death metal band formed in 2018, featuring former Sodom members Bernemann and Makka Freiwald. Debut "Rest In Violence" (2020) via Century Media.',
+            'descriptionDe' => 'Deutsche Thrash-/Death-Metal-Band, gegründet 2018, mit den ehemaligen Sodom-Mitgliedern Bernemann und Makka Freiwald. Debüt „Rest In Violence" (2020) bei Century Media.',
+            'descriptionEn' => 'German thrash/death metal band formed in 2018, featuring former Sodom members Bernemann and Makka Freiwald. Debut "Rest In Violence" (2020) via Century Media.',
         ],
         'gaerea' => [
             'genre' => 'Black Metal',
@@ -231,7 +259,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/1wXoI3Ajpv4WwQ3LmcrSBw',
             'appleMusic' => 'https://music.apple.com/us/artist/gaerea/1383640506',
             'bandcamp' => 'https://gaerea.bandcamp.com/',
-            'description' => 'Masked black metal band from Porto, Portugal, formed in 2016 and signed to Season of Mist, known for anonymity and an emotive, genre-bending sound.',
+            'descriptionDe' => 'Maskierte Black-Metal-Band aus Porto, Portugal, gegründet 2016 und bei Season of Mist unter Vertrag, bekannt für ihre Anonymität und einen emotionalen, genreübergreifenden Sound.',
+            'descriptionEn' => 'Masked black metal band from Porto, Portugal, formed in 2016 and signed to Season of Mist, known for anonymity and an emotive, genre-bending sound.',
         ],
         'overkill' => [
             'genre' => 'Thrash Metal',
@@ -239,7 +268,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/0NmYchKQ8JIR9QHYJA0FRe',
             'appleMusic' => 'https://music.apple.com/us/artist/overkill/263455457',
             'bandcamp' => 'https://overkillmetal.bandcamp.com/',
-            'description' => 'American thrash metal band formed in 1980 in New Jersey, fronted by Bobby "Blitz" Ellsworth and bassist D.D. Verni. One of the pioneering East Coast thrash bands.',
+            'descriptionDe' => 'US-amerikanische Thrash-Metal-Band, 1980 in New Jersey gegründet, mit Frontmann Bobby „Blitz" Ellsworth und Bassist D.D. Verni. Eine der wegweisenden Thrash-Bands der Ostküste.',
+            'descriptionEn' => 'American thrash metal band formed in 1980 in New Jersey, fronted by Bobby "Blitz" Ellsworth and bassist D.D. Verni. One of the pioneering East Coast thrash bands.',
         ],
         'alestorm' => [
             'genre' => 'Pirate Metal',
@@ -247,7 +277,8 @@ class SeedBandDetailsCommand extends Command
             'spotify' => 'https://open.spotify.com/artist/3OpqU68JpZlzvjAJj3B2Da',
             'appleMusic' => 'https://music.apple.com/us/artist/alestorm/272280214',
             'bandcamp' => 'https://alestorm.bandcamp.com/',
-            'description' => 'Scottish heavy metal band formed in Perth in 2004, dubbed "pirate metal" for its pirate-themed folk and power metal sound. Signed to Napalm Records.',
+            'descriptionDe' => 'Schottische Heavy-Metal-Band, 2004 in Perth gegründet, deren piratenthematisierter Folk- und Power-Metal-Sound als „Pirate Metal" bezeichnet wird. Unter Vertrag bei Napalm Records.',
+            'descriptionEn' => 'Scottish heavy metal band formed in Perth in 2004, dubbed "pirate metal" for its pirate-themed folk and power metal sound. Signed to Napalm Records.',
         ],
     ];
 
@@ -278,7 +309,8 @@ class SeedBandDetailsCommand extends Command
             }
 
             $this->fill($band->setGenre(...), $band->getGenre(), $d['genre'], $overwrite);
-            $this->fill($band->setDescription(...), $band->getDescription(), $d['description'], $overwrite);
+            $this->fill($band->setDescriptionDe(...), $band->getDescriptionDe(), $d['descriptionDe'], $overwrite);
+            $this->fill($band->setDescriptionEn(...), $band->getDescriptionEn(), $d['descriptionEn'], $overwrite);
             $this->fill($band->setInstagram(...), $band->getInstagram(), $d['instagram'], $overwrite);
             $this->fill($band->setSpotify(...), $band->getSpotify(), $d['spotify'], $overwrite);
             $this->fill($band->setAppleMusic(...), $band->getAppleMusic(), $d['appleMusic'], $overwrite);

--- a/src/Controller/API/FestivalApiController.php
+++ b/src/Controller/API/FestivalApiController.php
@@ -48,7 +48,10 @@ class FestivalApiController extends AbstractController
           'spotify' => $festivalBand->getSpotify(),
           'appleMusic' => $festivalBand->getAppleMusic(),
           'bandcamp' => $festivalBand->getBandcamp(),
-          'description' => $festivalBand->getDescription(),
+          'description' => [
+            'de' => $festivalBand->getDescriptionDe(),
+            'en' => $festivalBand->getDescriptionEn(),
+          ],
         ];
 
         if(isset($fesivalBandTimeSlot)){
@@ -84,7 +87,10 @@ class FestivalApiController extends AbstractController
                 'spotify' => $band->getSpotify(),
                 'appleMusic' => $band->getAppleMusic(),
                 'bandcamp' => $band->getBandcamp(),
-                'description' => $band->getDescription(),
+                'description' => [
+                    'de' => $band->getDescriptionDe(),
+                    'en' => $band->getDescriptionEn(),
+                ],
             ];
         }
 

--- a/src/Controller/Admin/BandCrudController.php
+++ b/src/Controller/Admin/BandCrudController.php
@@ -34,7 +34,8 @@ class BandCrudController extends AbstractCrudController
             TextField::new('spotify'),
             TextField::new('apple_music'),
             TextField::new('bandcamp'),
-            TextEditorField::new('description'),
+            TextEditorField::new('descriptionDe', 'Description (DE)'),
+            TextEditorField::new('descriptionEn', 'Description (EN)'),
             ];
     }
 }

--- a/src/Entity/Band.php
+++ b/src/Entity/Band.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use App\Repository\BandRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: BandRepository::class)]
@@ -39,8 +40,19 @@ class Band
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $bandcamp = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $description = null;
+    /**
+     * German description — the default language served to clients that do not
+     * request English explicitly.
+     */
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $descriptionDe = null;
+
+    /**
+     * English description — optional. Clients fall back to {@see $descriptionDe}
+     * when it is null.
+     */
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $descriptionEn = null;
 
     #[ORM\ManyToMany(targetEntity: Festival::class, mappedBy: 'bands', cascade: ['persist'])]
     private Collection $festivals;
@@ -158,14 +170,26 @@ class Band
         return $this;
     }
 
-    public function getDescription(): ?string
+    public function getDescriptionDe(): ?string
     {
-        return $this->description;
+        return $this->descriptionDe;
     }
 
-    public function setDescription(?string $description): static
+    public function setDescriptionDe(?string $descriptionDe): static
     {
-        $this->description = $description;
+        $this->descriptionDe = $descriptionDe;
+
+        return $this;
+    }
+
+    public function getDescriptionEn(): ?string
+    {
+        return $this->descriptionEn;
+    }
+
+    public function setDescriptionEn(?string $descriptionEn): static
+    {
+        $this->descriptionEn = $descriptionEn;
 
         return $this;
     }


### PR DESCRIPTION
Split the single band `description` into per-language fields served as a `{ de, en }` object on the band API endpoints.

- Band entity: descriptionDe (default) + descriptionEn, both nullable TEXT
- Migration: rename legacy `description` -> `description_en`, add `description_de`
- API: both band endpoints return description as a localized object
- Admin: separate DE/EN description editors
- Seed: German + English copy for all 28 Dong Open Air bands
- OpenAPI: new LocalizedText schema referenced by Band/BandDetail
- Docs: iOS LocalizedText Codable + integration guide

Breaking change: `description` was a string, now an object.